### PR TITLE
feat-wildcard: add wildcard channel support

### DIFF
--- a/src/event-hub.spec.ts
+++ b/src/event-hub.spec.ts
@@ -1,4 +1,4 @@
-import { Channel, EventHub } from './event-hub';
+import { Channel, EventHub, WildCardName } from './event-hub';
 
 describe('[Channel] ', () => {
   const channel = new Channel<boolean>('test');
@@ -56,14 +56,14 @@ describe('[EventHub]: subscribe', () => {
       eventData = data;
       publishCount++;
     });
-    expect(Object.keys(eventHub.channels).length).toBe(1);
+    expect(Object.keys(eventHub.channels).length).toBe(2);
   });
 
   it('Should not add another channel when I subscribe to the same channel', () => {
     eventHub.subscribe<boolean>('test', (data: boolean) => {
       eventData = data;
     });
-    expect(Object.keys(eventHub.channels).length).toBe(1);
+    expect(Object.keys(eventHub.channels).length).toBe(2);
   });
 
   it('Should add another channel when I subscribe to a unique name', () => {
@@ -71,7 +71,7 @@ describe('[EventHub]: subscribe', () => {
       eventData = data;
       publishCount++;
     });
-    expect(Object.keys(eventHub.channels).length).toBe(2);
+    expect(Object.keys(eventHub.channels).length).toBe(3);
   });
 
   it('Should call the callback when I publish an event', () => {
@@ -91,9 +91,31 @@ describe('[EventHub]: subscribe', () => {
     expect(sub).toHaveProperty('unsubscribe');
 
     const channels = eventHub.channels;
-    expect(Object.keys(channels).length).toBe(3);
+    expect(Object.keys(channels).length).toBe(4);
     sub.unsubscribe();
-    expect(Object.keys(channels).length).toBe(3);
+    expect(Object.keys(channels).length).toBe(4);
+  });
+});
+
+describe('[EventHub]: Wildcard Subscribe', () => {
+  const eventHub = new EventHub();
+  let eventData: string = '';
+  it('Should add my callback to the channel when I subscribe', () => {
+    eventHub.subscribe<string>('*', (data: string) => {
+      eventData = data;
+    });
+    expect(Object.keys(eventHub.channels).length).toBe(1);
+    expect(Object.keys(eventHub.channels[WildCardName].callbacks).length).toBe(1);
+  });
+
+  it('Should call the callback when I publish an event', () => {
+    eventHub.publish<string>('test', 'this is a test');
+    expect(eventData).toBe('this is a test');
+  });
+
+  it('Should call the callback when I publish an event no matter the channel published to', () => {
+    eventHub.publish<string>('another', 'this is another test');
+    expect(eventData).toBe('this is another test');
   });
 });
 

--- a/src/event-hub.ts
+++ b/src/event-hub.ts
@@ -1,4 +1,3 @@
-
 /**
  * Function signature for callbacks registered for receiving events on a channel.
  *
@@ -13,6 +12,11 @@
  * };
  */
 export type EventCallback<TEvent> = (event: TEvent) => void;
+
+/**
+ * Constant representing the wild card channel where ALL events get broadcast to.
+ */
+export const WildCardName = '*';
 
 /**
  * Subscription object returned when a callback is subscribed to an EventHub channel.
@@ -194,12 +198,15 @@ export class EventHub {
 
   /**
    * Creates a new EventHub instance.
-   * 
+   *
    * @description
-   * The constructor initializes an empty channels object. Channels are created dynamically
-   * as they are subscribed to or published to.
+   * The constructor initializes a wildcard channel object.
+   * Channels are created dynamically as they are subscribed to or published to.
    */
-  constructor() {}
+  constructor() {
+    // Create the Wildcard Channel
+    this._channels[WildCardName] = new Channel<any>(WildCardName);
+  }
 
   /**
    * Retrieves all channels currently subscribed to the event hub.
@@ -238,6 +245,9 @@ export class EventHub {
           this._channels[channel] = new Channel<TEvent>(channel);
       }
       this._channels[channel].publish(data);
+
+      // also publish to the wildcard channel
+      this._channels[WildCardName].publish(data);
   }
 
   /**


### PR DESCRIPTION
Adding in support for a wildcard channel so that subscribers can receive ALL events published to the EventHub