### PR TITLE
Improviment: comments moved from the abstract class to the IConnector interface.

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -1,15 +1,58 @@
 import {EventHub, Subscription} from "./event-hub";
 
 export interface IConnector {
+
+  /** 
+   * The event hubs that this connector is connected to
+   */
   eventHubs: EventHub[];
+
+  /**
+   * The name of the connector.
+   */
   name: string;
 
+  /**
+   * Enable a Connector to service multiple event hubs.
+   *
+   * @param hub
+   */
   addEventHub(hub: EventHub): IConnector;
 
+   /**
+   * Initialise a Connector with an event hub.
+   *
+   * @description
+   * This method handles the initialization logic when connecting a connector to an event hub.
+   * It can be overridden by child classes to implement custom initialization behavior.
+   *
+   * @param hub - The EventHub instance to initialize the connector with
+   * @param channels - Array of channel names that this connector should subscribe to
+   * @returns void
+   * @protected
+   */
   initialiseEventHub(hub: EventHub, channels: string[]): IConnector;
 
+  /**
+   * Connect to the EventHub.
+   *
+   * @description
+   * This method is called when the connector is added to the EventHub.
+   * It allows the connector to perform any necessary setup or initialization.
+   *
+   * @param hub
+   * @param channels
+   */
   connect(hub: EventHub, channels: string[]): Promise<void>;
 
+  /**
+   * Disconnect from the EventHub.
+   *
+   * @description
+   * This method is called when the connector is removed from the EventHub.
+   * It allows the connector to perform any necessary cleanup or teardown.
+   *
+   */
   disconnect(): Promise<void>;
 }
 
@@ -26,13 +69,9 @@ export abstract class BaseConnector implements IConnector {
   protected channels: string[] = [];
 
   eventHubs : EventHub[] = [];
+
   name: string = 'BaseConnector';
 
-  /**
-   * Enable a Connector to service multiple event hubs.
-   *
-   * @param hub
-   */
   addEventHub(hub: EventHub): IConnector {
     this.eventHubs.push(hub);
     this.initialiseEventHub(hub, this.channels);
@@ -40,40 +79,12 @@ export abstract class BaseConnector implements IConnector {
     return this;
   }
 
-  /**
-   * Initialise a Connector with an event hub.
-   *
-   * @description
-   * This method handles the initialization logic when connecting a connector to an event hub.
-   * It can be overridden by child classes to implement custom initialization behavior.
-   *
-   * @param hub - The EventHub instance to initialize the connector with
-   * @param channels - Array of channel names that this connector should subscribe to
-   * @returns void
-   * @protected
-   */
   abstract initialiseEventHub(hub: EventHub, channels: string[]): IConnector;
 
-  /**
-   * Connect to the EventHub.
-   *
-   * @description
-   * This method is called when the connector is added to the EventHub.
-   * It allows the connector to perform any necessary setup or initialization.
-   *
-   * @param hub
-   * @param channels
-   */
+  
   abstract connect(hub: EventHub, channels: string[]): Promise<void>;
 
-  /**
-   * Disconnect from the EventHub.
-   *
-   * @description
-   * This method is called when the connector is removed from the EventHub.
-   * It allows the connector to perform any necessary cleanup or teardown.
-   *
-   */
+
   abstract disconnect(): Promise<void>;
 
 }


### PR DESCRIPTION
## What was done ?

The comment moved of abstract class to the interface, it is interesting because new implementations of interface `IConnectors` can extend comments automatically when over the mouse about the field in the abstract class.

## Exemple
![image](https://github.com/user-attachments/assets/9bca530f-05c4-4b10-967b-cb7b1f25c1c5)

## Commit

b0542bb9ed655be72a6a728073ad06b48c68ffcc

## Issue solved

#17 