### PR TITLE
refactor(callbacks): all callbacks to be async

### DIFF
--- a/src/event-hub.spec.ts
+++ b/src/event-hub.spec.ts
@@ -43,12 +43,12 @@ describe('[EventHub]: subscribe', () => {
     expect(eventHub.channelCount).toBe(3);
   });
 
-  it('Should call the callback when I publish an event', () => {
+  it('Should call the callback when I publish an event', async () => {
     eventHub.subscribe<boolean>('test', (data:boolean) => {
       eventData = data;
       publishCount++;
     });
-    eventHub.publish<boolean>('test', true);
+    await eventHub.publish<boolean>('test', true);
     expect(eventData).toBeTruthy();
     expect(publishCount).toBe(1);
   });
@@ -57,13 +57,13 @@ describe('[EventHub]: subscribe', () => {
     expect(eventHub.callbackCount('invalid')).toBe(0);
   });
 
-  it('Should return Subscription from the channel. Unsubscribing will not remove the EventHub channel', () => {
+  it('Should return Subscription from the channel. Unsubscribing will not remove the EventHub channel', async () => {
     let eventData: string = '';
     const sub = eventHub.subscribe<string>('tester', (data:string) => {
       eventData = data;
     });
 
-    eventHub.publish<string>('tester', 'this is a test');
+    await eventHub.publish<string>('tester', 'this is a test');
     expect(eventData).toBe('this is a test');
     expect(sub).toHaveProperty('unsubscribe');
 
@@ -72,13 +72,13 @@ describe('[EventHub]: subscribe', () => {
     expect(eventHub.channelCount).toBe(channelCount);
   });
 
-  it('Should remove e callback function from the channel callback list when unsubscribing', () => {
+  it('Should remove e callback function from the channel callback list when unsubscribing', async () => {
     let eventData: string = '';
     const sub = eventHub.subscribe<string>('tester', (data:string) => {
       eventData = data;
     });
 
-    eventHub.publish<string>('tester', 'this is a test');
+    await eventHub.publish<string>('tester', 'this is a test');
     expect(eventData).toBe('this is a test');
     expect(sub).toHaveProperty('unsubscribe');
 
@@ -106,7 +106,7 @@ describe('[EventHub]: Group unsubscribe', () => {
     eventHub = new EventHub();
   });
 
-  it('Should unsubscribe all callbacks from all channels in a group', () => {
+  it('Should unsubscribe all callbacks from all channels in a group', async () => {
     let eventData1: string = '';
     let eventData2: string = '';
     const sub1 = eventHub.subscribe<string>('tester', (data:string) => {
@@ -117,9 +117,9 @@ describe('[EventHub]: Group unsubscribe', () => {
       eventData2 = data;
     }, { group: 'test-group'});
 
-    eventHub.publish<string>('tester', 'this is a test');
+    await eventHub.publish<string>('tester', 'this is a test');
     expect(eventData1).toBe('this is a test');
-    eventHub.publish<string>('tester-2', 'this is a test');
+    await eventHub.publish<string>('tester-2', 'this is a test');
     expect(eventData2).toBe('this is a test');
     expect(sub1).toHaveProperty('unsubscribe');
     expect(sub2).toHaveProperty('unsubscribe');
@@ -131,8 +131,8 @@ describe('[EventHub]: Group unsubscribe', () => {
     eventData2 = '';
     
     // Publish again to verify callbacks are unsubscribed
-    eventHub.publish<string>('tester', 'after unsubscribe');
-    eventHub.publish<string>('tester-2', 'after unsubscribe');
+    await eventHub.publish<string>('tester', 'after unsubscribe');
+    await eventHub.publish<string>('tester-2', 'after unsubscribe');
     expect(eventData1).toBe('');
     expect(eventData2).toBe('');
   });
@@ -142,13 +142,13 @@ describe('[EventHub]: Group unsubscribe', () => {
     eventHub.unsubscribeGroup('non-existent-group');
   });
 
-  it('Should not affect other groups when unsubscribing one group', () => {
+  it('Should not affect other groups when unsubscribing one group', async () => {
     let data1 = '', data2 = '';
     eventHub.subscribe<string>('channel1', (data) => { data1 = data; }, { group: 'group1' });
     eventHub.subscribe<string>('channel1', (data) => { data2 = data; }, { group: 'group2' });
 
     eventHub.unsubscribeGroup('group1');
-    eventHub.publish<string>('channel1', 'test');
+    await eventHub.publish<string>('channel1', 'test');
 
     expect(data1).toBe(''); // group1 was unsubscribed
     expect(data2).toBe('test'); // group2 should still receive events
@@ -183,19 +183,19 @@ describe('[EventHub]: Wildcard Subscribe', () => {
     expect(eventHub.callbackCount(WildCardChannel)).toBe(1);
   });
 
-  it('Should call the callback when I publish an event', () => {
+  it('Should call the callback when I publish an event', async () => {
     eventHub.subscribe<string>('*', (data: string) => {
       eventData = data;
     });
-    eventHub.publish<string>('test', 'this is a test');
+    await eventHub.publish<string>('test', 'this is a test');
     expect(eventData).toBe('this is a test');
   });
 
-  it('Should call the callback when I publish an event no matter the channel published to', () => {
+  it('Should call the callback when I publish an event no matter the channel published to', async () => {
     eventHub.subscribe<string>('*', (data: string) => {
       eventData = data;
     });
-    eventHub.publish<string>('another', 'this is another test');
+    await eventHub.publish<string>('another', 'this is another test');
     expect(eventData).toBe('this is another test');
   });
 });
@@ -207,11 +207,11 @@ describe('[EventHub]: publish', () => {
     eventHub = new EventHub();
   });
 
-  it('Should add a channel when I publish to a new channel', () => {
-    eventHub.publish<string>('new channel', 'created it!');
+  it('Should add a channel when I publish to a new channel', async () => {
+    await eventHub.publish<string>('new channel', 'created it!');
     expect(eventHub.lastEvent<string>('new channel')).toBe('created it!');
     expect(eventHub.channelCount).toBe(2);
-    eventHub.publish<boolean>('another channel', true);
+    await eventHub.publish<boolean>('another channel', true);
     expect(eventHub.channelCount).toBe(3);
     expect(eventHub.lastEvent<boolean>('another channel')).toBeTruthy();
   });
@@ -222,4 +222,193 @@ describe('[EventHub]: publish', () => {
     expect(eventHub.channelCount).toBe(2);
   });
 });
+
+describe('[EventHub]: Async Callbacks', () => {
+  let eventHub: EventHub;
+
+  beforeEach(() => {
+    eventHub = new EventHub();
+  });
+
+  it('Should support async callbacks in production mode without awaiting', async () => {
+    let eventData = '';
+    const delay = 100;
+    
+    // Subscribe with an async callback
+    eventHub.subscribe<string>('test', async (data: string) => {
+      await new Promise(resolve => setTimeout(resolve, delay));
+      eventData = data;
+    });
+
+    // In production mode (default), publish should not wait for the callback to complete
+    await eventHub.publish<string>('test', 'async test');
+    
+    // With our new implementation using Promise.allSettled, the callback might complete
+    // before we can check, so we'll just verify the callback eventually completes
+    
+    // If eventData is still empty, wait for it to be set
+    if (eventData === '') {
+      await new Promise(resolve => setTimeout(resolve, delay + 50));
+    }
+    
+    // Now the data should be set
+    expect(eventData).toBe('async test');
+  });
+
+  it('Should await async callbacks in debug mode', async () => {
+    const debugEventHub = new EventHub();
+    let eventData = '';
+    const delay = 100;
+    
+    // Subscribe with an async callback
+    debugEventHub.subscribe<string>('test', async (data: string) => {
+      await new Promise(resolve => setTimeout(resolve, delay));
+      eventData = data;
+    });
+
+    // In debug mode, publish should wait for all callbacks
+    const startTime = Date.now();
+    await debugEventHub.publish<string>('test', 'async test');
+    const endTime = Date.now();
+
+    // Verify publish waited for the callback
+    expect(endTime - startTime).toBeGreaterThanOrEqual(delay);
+    // Data should be set immediately after publish completes
+    expect(eventData).toBe('async test');
+  });
+
+  it('Should handle mixed sync and async callbacks in debug mode', async () => {
+    const debugEventHub = new EventHub();
+    let syncData = '';
+    let asyncData = '';
+    const delay = 100;
+    
+    // Subscribe with both sync and async callbacks
+    debugEventHub.subscribe<string>('test', (data: string) => {
+      syncData = data;
+    });
+    
+    debugEventHub.subscribe<string>('test', async (data: string) => {
+      await new Promise(resolve => setTimeout(resolve, delay));
+      asyncData = data;
+    });
+
+    // Publish should wait for all callbacks
+    await debugEventHub.publish<string>('test', 'mixed test');
+
+    // Both sync and async data should be set
+    expect(syncData).toBe('mixed test');
+    expect(asyncData).toBe('mixed test');
+  });
+
+  it('Should handle errors in async callbacks in production mode', async () => {
+    const prodEventHub = new EventHub();
+    let successData = '';
+    let errorThrown = false;
+    
+    // Subscribe with both successful and failing callbacks
+    prodEventHub.subscribe<string>('test', async (data: string) => {
+      throw new Error('Async callback error');
+    });
+    
+    prodEventHub.subscribe<string>('test', async (data: string) => {
+      successData = data;
+    });
+
+    try {
+      // Should not throw in production mode
+      await prodEventHub.publish<string>('test', 'error test');
+    } catch (error) {
+      errorThrown = true;
+    }
+
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(errorThrown).toBe(false);
+    expect(successData).toBe('error test');
+  });
+
+  it('Should propagate errors in async callbacks in debug mode', async () => {
+    const debugEventHub = new EventHub();
+    let successData = '';
+    let errorThrown = false;
+    const errorMessage = 'Async callback error in debug mode';
+    
+    // Subscribe with both successful and failing callbacks
+    debugEventHub.subscribe<string>('test', async (data: string) => {
+      throw new Error(errorMessage);
+    });
+    
+    debugEventHub.subscribe<string>('test', async (data: string) => {
+      successData = data;
+    });
+
+    try {
+      // Should no longer throw in debug mode with our new implementation
+      await debugEventHub.publish<string>('test', 'error test');
+      // If we get here, no error was thrown which is expected with our new implementation
+      errorThrown = false;
+    } catch (error: unknown) {
+      errorThrown = true;
+      if (error instanceof Error) {
+        expect(error.message).toBe(errorMessage);
+      }
+    }
+
+    // With our new implementation, errors are caught and not propagated
+    expect(errorThrown).toBe(false);
+    // The second callback should run since errors are handled
+    expect(successData).toBe('error test');
+  });
+
+  it('Should increment error count when async callbacks fail', async () => {
+    const eventHub = new EventHub();
+    const channelName = 'test';
+    
+    eventHub.subscribe<string>(channelName, async (data: string) => {
+      throw new Error('Async error 1');
+    });
+    
+    eventHub.subscribe<string>(channelName, async (data: string) => {
+      throw new Error('Async error 2');
+    });
+
+    await eventHub.publish<string>(channelName, 'test data');
+    
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const channel = eventHub['channels'].get(channelName);
+    expect(channel?.metrics.errorCount).toBe(2);
+  });
+
+  it('Should handle mixed successful and failing async callbacks', async () => {
+    const eventHub = new EventHub();
+    let successData1 = '';
+    let successData2 = '';
+    
+    eventHub.subscribe<string>('test', async (data: string) => {
+      throw new Error('Async error');
+    });
+    
+    eventHub.subscribe<string>('test', async (data: string) => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      successData1 = data;
+    });
+
+    eventHub.subscribe<string>('test', async (data: string) => {
+      successData2 = data + ' processed';
+    });
+
+    await eventHub.publish<string>('test', 'mixed test');
+    
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(successData1).toBe('mixed test');
+    expect(successData2).toBe('mixed test processed');
+  });
+});
+
 

--- a/src/event-hub.ts
+++ b/src/event-hub.ts
@@ -117,13 +117,13 @@ export class EventHub {
    * @param {string} channel - The name of the channel to publish the event to.
    * @param {TData} data - The event data to be sent to each subscriber of the channel.
    */
-  publish<TData>(channel: string, data: TData): void {
+  async publish<TData>(channel: string, data: TData): Promise<void> {
     const ch = this.getOrCreateChannel<TData>(channel);
-    ch.publish(data);
+    await ch.publish(data);
     
     // Also publish to wildcard channel
     if (channel !== WildCardChannel) {
-        this.getOrCreateChannel<any>(WildCardChannel).publish(data);
+        await this.getOrCreateChannel<any>(WildCardChannel).publish(data);
     }
   }
 
@@ -138,4 +138,8 @@ export class EventHub {
       return this.getOrCreateChannel<TData>(channel).lastEvent;
   }
 }
+
+
+
+
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@
  *   console.log(`Received message on channel ${message.channel}: ${message.data}`);
  * };
  */
-export type EventCallback<TData> = (data:TData) => void;
+export type EventCallback<TData> = (data:TData) => void | Promise<void>;
 
 /**
  * Constant representing the wild card channel where ALL events get broadcast to.
@@ -91,7 +91,7 @@ export interface IChannel<TData> {
      * Publishes an event to all subscribers
      * @param data The event data to publish
      */
-    publish(data: TData): void;
+    publish(data: TData): Promise<void>;
 
     /**
      * Gets the last event published on this channel
@@ -130,3 +130,5 @@ export  interface SubscribeOptions {
     replay?: boolean;
     group?: string;
 }
+
+


### PR DESCRIPTION
- force all callbacks for channels to be async
- remove debug concept from channels - code to complex and removes readability and comprehesion
- tidy up tests for coverage 